### PR TITLE
WikilogUtils: Replace WikiPage::getText() with getContent()

### DIFF
--- a/WikilogUtils.php
+++ b/WikilogUtils.php
@@ -210,7 +210,16 @@ class WikilogUtils {
 		$parser->startExternalParse( $title, $parserOpt, Parser::OT_HTML );
 
 		# Parse article.
-		$arttext = $article->getText();
+		$articleContent = $article->getContent();
+		if ( !($articleContent instanceof TextContent) ){
+			# Restore default behavior.
+			if ( $feed ) {
+				WikilogParser::enableFeedParsing( $saveFeedParse );
+				WikilogParser::expandLocalUrls( $saveExpUrls );
+			}
+			return array( $article, '' );
+		}
+		$arttext = $articleContent->getNativeData();
 		$parserOutput = $parser->parse( $arttext, $title, $parserOpt );
 
 		# Save in parser cache.


### PR DESCRIPTION
Replace `WikiPage::getText()` with
`WikiPage::getContent()->getNativeData()` in
`WikilogUtils.php`, since `WikiPage::getText()` had been removed
from `WikiPage`.

Bug: T179532