### PR TITLE
Replace deprecated DB_SLAVE to DB_REPLICA

### DIFF
--- a/SpecialWikilog.php
+++ b/SpecialWikilog.php
@@ -421,7 +421,7 @@ class SpecialWikilog
 	/* Get possible options for combo-boxes */
 	protected function getSelectOptions()
 	{
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$select_options = array();
 
 		/* Wikilogs */
@@ -494,7 +494,7 @@ class SpecialWikilog
 
 	/* Get possible Author options for combo-box */
 	protected function getAuthorOptions() {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 	}
 
 	/**

--- a/SpecialWikilogSubscriptions.php
+++ b/SpecialWikilogSubscriptions.php
@@ -52,7 +52,7 @@ class SpecialWikilogSubscriptions
         }
 
         $id = $wgUser->getId();
-        $dbr = wfGetDB( DB_SLAVE );
+        $dbr = wfGetDB( DB_REPLICA );
 
         $opts = array(
             'blogs' => array(),
@@ -322,7 +322,7 @@ END_STRING;
     public static function sendEmails( &$article, $text ) {
         global $wgUser, $wgPasswordSender, $wgServer, $wgContLang;
 
-        $dbr = wfGetDB( DB_SLAVE );
+        $dbr = wfGetDB( DB_REPLICA );
 
         $title = $article->getTitle();
         $wi = Wikilog::getWikilogInfo( $title );

--- a/WikilogCalendar.php
+++ b/WikilogCalendar.php
@@ -112,7 +112,7 @@ class WikilogCalendar
     static function sidebarCalendar($pager)
     {
         global $wgRequest, $wgWikilogNumArticles;
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = wfGetDB(DB_REPLICA);
         // Make limit and offset work, but only in the terms of
         // selecting displayed MONTHS, not DATES. I.e. if there
         // are posts selected from 2011-01-15 to 2011-02-15,

--- a/WikilogComment.php
+++ b/WikilogComment.php
@@ -173,7 +173,7 @@ class WikilogComment
 	 * Load current revision of comment wikitext.
 	 */
 	public function loadText() {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$rev = Revision::loadFromId( $dbr, $this->mCommentRev );
 		if ( $rev ) {
 			$this->mText = $rev->getText();
@@ -312,7 +312,7 @@ class WikilogComment
 			$args[5] = $this->mParentObj->mUserText;
 		}
 		// Get user IDs for notification
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$id = $this->mSubject->getArticleId();
 		$parent = Title::makeTitle( $this->mSubject->getNamespace(), $this->mSubject->getBaseText() );
 		$wlid = $parent->getArticleId();
@@ -637,7 +637,7 @@ class WikilogComment
 	 * @return New WikilogComment object, or NULL if comment doesn't exist.
 	 */
 	public static function newFromID( $id ) {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$row = self::loadFromID( $dbr, $id );
 		return self::newFromRow( $row );
 	}
@@ -649,7 +649,7 @@ class WikilogComment
 	 * @return New WikilogComment object, or NULL if comment doesn't exist.
 	 */
 	public static function newFromPageID( $pageid ) {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$row = self::loadFromPageID( $dbr, $pageid );
 		return self::newFromRow( $row );
 	}

--- a/WikilogCommentPager.php
+++ b/WikilogCommentPager.php
@@ -233,7 +233,7 @@ class WikilogCommentThreadPager
 		$this->mQuery->setLimit( 'thread', $this->mLimit );
 
 		// Execute query
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$res = $this->mQuery->select( $dbr, array(), false );
 		$nchild = array();
 		$rows = array();

--- a/WikilogCommentsPage.php
+++ b/WikilogCommentsPage.php
@@ -435,7 +435,7 @@ class WikilogCommentsPage
 		if ( $this->includeSubpageComments() ) {
 			$msg = $one ? 'wikilog-do-unsubscribe-all' : 'wikilog-do-subscribe-all';
 		} elseif ( !$this->mSingleComment ) {
-			$dbr = wfGetDB( DB_SLAVE );
+			$dbr = wfGetDB( DB_REPLICA );
 			// Is it the user talk page? If yes, he can't unsubscribe.
 			if ( $this->mSubject->getNamespace() == NS_USER &&
 				$this->mSubject->getText() == $wgUser->getName() ) {
@@ -491,7 +491,7 @@ class WikilogCommentsPage
 	 */
 	public function isSubscribed( $itemid ) {
 		global $wgUser;
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$r = $dbr->selectField( 'wikilog_subscriptions', 'ws_yes', array( 'ws_page' => $itemid, 'ws_user' => $wgUser->getID() ), __METHOD__ );
 		if ( $r === false ) {
 			$r = NULL;

--- a/WikilogFeed.php
+++ b/WikilogFeed.php
@@ -83,7 +83,7 @@ abstract class WikilogFeed
 		$this->mFormat = $format;
 		$this->mQuery = $query;
 		$this->mLimit = $limit;
-		$this->mDb = wfGetDB( DB_SLAVE );
+		$this->mDb = wfGetDB( DB_REPLICA );
 		$this->mIndexField = $this->getIndexField();
 
 		# Retrieve copyright notice.

--- a/WikilogItem.php
+++ b/WikilogItem.php
@@ -246,7 +246,7 @@ class WikilogItem
 	 * @return New WikilogItem object, or NULL if article doesn't exist.
 	 */
 	public static function newFromID( $id ) {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$row = self::loadFromID( $dbr, $id );
 		if ( $row ) {
 			return self::newFromRow( $row );
@@ -306,7 +306,7 @@ class WikilogItem
 	 * of WikilogItem.
 	 */
 	public static function selectTables( $dbr = null ) {
-		if ( !$dbr ) $dbr = wfGetDB( DB_SLAVE );
+		if ( !$dbr ) $dbr = wfGetDB( DB_REPLICA );
 		$page = $dbr->tableName( 'page' );
 		return array(
 			'tables' => array(

--- a/WikilogItemPager.php
+++ b/WikilogItemPager.php
@@ -548,7 +548,7 @@ class WikilogArchivesPager
 			$attribs['class'] = 'wl-draft';
 		}
 		if ( $wgUser->getID() ) {
-			$dbr = wfGetDB( DB_SLAVE );
+			$dbr = wfGetDB( DB_REPLICA );
 			$result = $dbr->select(
 				array( 'wikilog_comments', 'page_last_visit' ),
 				'COUNT(*)',

--- a/WikilogMainPage.php
+++ b/WikilogMainPage.php
@@ -199,7 +199,7 @@ class WikilogMainPage
 	 * Returns wikilog information as formatted HTML.
 	 */
 	protected function formatWikilogInformation( $skin ) {
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$row = $dbr->selectRow(
 			array( 'wikilog_posts', 'page' ),
@@ -268,7 +268,7 @@ class WikilogMainPage
 			) );
 		} else {
 			global $wgWikilogNamespaces;
-			$dbr = wfGetDB( DB_SLAVE );
+			$dbr = wfGetDB( DB_REPLICA );
 			$r = $dbr->select( 'page', 'page_id', array(
 				'page_namespace' => $wgWikilogNamespaces,
 				'page_title NOT LIKE \'%/%\'',
@@ -409,7 +409,7 @@ class WikilogMainPage
 	 */
 	private function loadWikilogData() {
 		if ( !$this->mWikilogDataLoaded ) {
-			$dbr = wfGetDB( DB_SLAVE );
+			$dbr = wfGetDB( DB_REPLICA );
 			$data = $this->getWikilogDataFromId( $dbr, $this->getId() );
 			if ( $data ) {
 				$this->mWikilogSubtitle = unserialize( $data->wlw_subtitle );

--- a/WikilogQuery.php
+++ b/WikilogQuery.php
@@ -756,7 +756,7 @@ class WikilogCommentQuery
 
 		# Sort order and limits
 		if ( $this->mSort == 'thread' ) {
-			$dbr = wfGetDB( DB_SLAVE );
+			$dbr = wfGetDB( DB_REPLICA );
 			$first = $last = $back = false;
 			if ( $this->mNextCommentId ) {
 				// Backward navigation: next comment ID is set from the outside.

--- a/WikilogUtils.php
+++ b/WikilogUtils.php
@@ -551,7 +551,7 @@ class WikilogUtils {
 
 	public static function getOldestRevision( $articleId ) {
 		$row = NULL;
-		$db = wfGetDB( DB_SLAVE );
+		$db = wfGetDB( DB_REPLICA );
 		$revSelectFields = Revision::selectFields();
 		while ( !$row ) {
 			$row = $db->selectRow(


### PR DESCRIPTION
The former was [removed in MediaWiki 1.34](https://www.mediawiki.org/wiki/Release_notes/1.34#Breaking_changes_in_1.34).