### PR TITLE
Replace deprecated SpecialPage::getTitle() to SpecialPage::getPageTitle()

### DIFF
--- a/SpecialWikilog.php
+++ b/SpecialWikilog.php
@@ -361,7 +361,7 @@ class SpecialWikilog
 	protected function getHeader( FormOptions $opts ) {
 		global $wgScript;
 
-		$out = Html::hidden( 'title', $this->getTitle()->getPrefixedText() );
+		$out = Html::hidden( 'title', $this->getPageTitle()->getPrefixedText() );
 
 		$out .= $this->getQueryForm( $opts );
 

--- a/SpecialWikilogSubscriptions.php
+++ b/SpecialWikilogSubscriptions.php
@@ -324,7 +324,7 @@ END_STRING;
 
         $dbr = wfGetDB( DB_SLAVE );
 
-        $title = $article->getTitle();
+        $title = $article->getPageTitle();
         $wi = Wikilog::getWikilogInfo( $title );
         $args = array(
             $title->getSubpageText(),


### PR DESCRIPTION
SpecialPage::getTitle(), deprecated in 1.23, [removed in 1.34](https://www.mediawiki.org/wiki/Release_notes/1.34).